### PR TITLE
chore: remove zoo from suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,8 +36,7 @@ Imports:
     tf
 Suggests:
     rpart,
-    testthat (>= 3.0.0),
-    zoo
+    testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
Not sure what the purpose was, but zoo is currently not used anywhere, so we can remove it from suggests