### PR TITLE
tests: migrate to train_pipeop and predict_pipeop in tests

### DIFF
--- a/tests/testthat/test_PipeOpCor.R
+++ b/tests/testthat/test_PipeOpCor.R
@@ -11,7 +11,7 @@ test_that("PipeOpCor works", {
   task = as_task_regr(dt, target = "y")
 
   pop = po("fda.cor")
-  task_cor = pop$train(list(task))[[1L]]
+  task_cor = train_pipeop(pop, list(task))[[1L]]
   expect_task(task_cor)
   new_data = task_cor$data()
   expect_identical(dim(new_data), c(100L, 4L))
@@ -23,19 +23,18 @@ test_that("PipeOpCor works", {
   # single col gives warning
   task$select("x1")
   pop = po("fda.cor")
-  expect_warning(pop$train(list(task)), "task has less than 2 columns")
-  task_cor = suppressWarnings(pop$train(list(task))[[1L]])
+  expect_warning(task_cor <- train_pipeop(pop, list(task))[[1L]], "task has less than 2 columns")
   expect_identical(task$data(), task_cor$data())
 
   # different domain throws error
   dt_domain = copy(dt)[, x1 := tf::tf_rgp(100L, 20:120)]
   task = as_task_regr(dt_domain, target = "y")
   pop = po("fda.cor")
-  expect_error(pop$train(list(task)), "Domain of x1 and x2 do not match")
+  expect_error(train_pipeop(pop, list(task)), "Domain of x1 and x2 do not match")
 
   # does not touch irreg
   dt[, x1 := tf::tf_sparsify(x1)]
   task = as_task_regr(dt, target = "y")
-  task_cor = pop$train(list(task))[[1L]]
+  task_cor = train_pipeop(pop, list(task))[[1L]]
   expect_set_equal(task_cor$feature_names, c("x1", "x2_x3_cor"))
 })

--- a/tests/testthat/test_PipeOpFDAFlatten.R
+++ b/tests/testthat/test_PipeOpFDAFlatten.R
@@ -7,7 +7,7 @@ test_that("PipeOpFDAFlatten - basic properties", {
 test_that("PipeOpFDAFlatten works", {
   task = tsk("fuel")
   pop = po("fda.flatten")
-  x = pop$train(list(task))[[1L]]
+  x = train_pipeop(pop, list(task))[[1L]]
   expected_features = c(
     "h20",
     paste0("UVVIS_", 1:134),
@@ -15,8 +15,9 @@ test_that("PipeOpFDAFlatten works", {
   )
   expect_set_equal(x$feature_names, expected_features)
 
+  pop = po("fda.flatten")
   pop$param_set$values$affect_columns = selector_name("UVVIS")
-  x = pop$train(list(task))[[1L]]
+  x = train_pipeop(pop, list(task))[[1L]]
   expected_features = c(
     "h20",
     paste0("UVVIS_", 1:134),
@@ -24,13 +25,10 @@ test_that("PipeOpFDAFlatten works", {
   )
   expect_set_equal(x$feature_names, expected_features)
 
+  pop = po("fda.flatten")
   pop$param_set$values$affect_columns = selector_name("..xyz")
-  x = pop$train(list(task))[[1L]]
-  expected_features = c(
-    "h20",
-    "UVVIS",
-    "NIR"
-  )
+  x = train_pipeop(pop, list(task))[[1L]]
+  expected_features = c("h20", "UVVIS", "NIR")
   expect_set_equal(x$feature_names, expected_features)
 })
 
@@ -39,7 +37,7 @@ test_that("PipeOpFDAFlatten works with name clashes", {
   dt$NIR_1 = 1
   task = as_task_regr(dt, target = "heatan")
   pop = po("fda.flatten")
-  taskout = pop$train(pop$train(list(task)))[[1L]]
+  taskout = train_pipeop(pop, train_pipeop(pop, list(task)))[[1L]]
   expect_true("NIR_1_1" %in% taskout$feature_names)
 })
 
@@ -54,7 +52,7 @@ test_that("PipeOpFDAFlatten works with tfr and tfi", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.flatten")
-  task_flat = pop$train(list(task))[[1L]]
+  task_flat = train_pipeop(pop, list(task))[[1L]]
   expected = data.table(
     y = 1:2, f_1 = c(1, 3), f_2 = c(2, 5), f_3 = c(5, 10), f_4 = c(5, 2), f_5 = c(7, 12)
   )
@@ -71,7 +69,7 @@ test_that("PipeOpFDAFlatten works with tfr and tfi", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.flatten")
-  task_flat = pop$train(list(task))[[1L]]
+  task_flat = train_pipeop(pop, list(task))[[1L]]
   expected = data.table(
     y = 1:2, f_1 = c(NA, 1), f_2 = c(NA, 3), f_3 = c(2, 4), f_4 = c(5, 5), f_5 = c(6, 6), f_6 = c(NA, 7)
   )

--- a/tests/testthat/test_PipeOpFDAInterpolate.R
+++ b/tests/testthat/test_PipeOpFDAInterpolate.R
@@ -15,13 +15,19 @@ test_that("PipeOpFDAInterpol input validation works", {
   expect_error(po("fda.interpol", grid = 1:3, method = "cube"))
   task = tsk("fuel")
   pop = po("fda.interpol", grid = 1:3, left = 1, right = 2)
-  expect_error(pop$train(list(task)))
+  expect_error(train_pipeop(pop, list(task)))
   pop = po("fda.interpol", grid = 10L, left = 2, right = 1)
-  expect_error(pop$train(list(task)))
+  expect_error(train_pipeop(pop, list(task)))
   pop = po("fda.interpol", grid = 10L, left = 2)
-  expect_error(pop$train(list(task)), "Either both or none of 'left' and 'right' must be specified.")
+  expect_error(
+    train_pipeop(pop, list(task)),
+    "Either both or none of 'left' and 'right' must be specified."
+  )
   pop = po("fda.interpol", grid = 10L, right = 2)
-  expect_error(pop$train(list(task)), "Either both or none of 'left' and 'right' must be specified.")
+  expect_error(
+    train_pipeop(pop, list(task)),
+    "Either both or none of 'left' and 'right' must be specified."
+  )
 })
 
 test_that("PipeOpFDAInterpol extrapolation works", {
@@ -34,13 +40,13 @@ test_that("PipeOpFDAInterpol extrapolation works", {
   dt_in = data.table(y = 1:2, f = tf::tfd(dt, id = "id", arg = "arg", value = "value"))
   task = as_task_regr(dt_in, target = "y")
   pop = po("fda.interpol", grid = 1:5, method = "fill_extend")
-  actual = pop$train(list(task))[[1L]]$data()
+  actual = train_pipeop(pop, list(task))[[1L]]$data()
   setnafill(dt, fill = 2L)
   expected = data.table(y = 1:2, f = tf::tfd(dt, id = "id", arg = "arg", value = "value"))
   expect_equal(actual, expected, ignore_attr = TRUE)
   # throw warning if extrapolation is not possible
   pop = po("fda.interpol", grid = 1:5)
-  expect_warning(pop$train(list(task)))
+  expect_warning(train_pipeop(pop, list(task)))
 })
 
 test_that("PipeOpFDAInterpol works with minmax", {
@@ -54,7 +60,7 @@ test_that("PipeOpFDAInterpol works with minmax", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = "minmax")
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   expect_equal(task_interpol$data(), dt)
 
   # tfi works with same min and max
@@ -67,7 +73,7 @@ test_that("PipeOpFDAInterpol works with minmax", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = "minmax")
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 5L),
     arg = rep(1:5, 2L),
@@ -87,7 +93,7 @@ test_that("PipeOpFDAInterpol works with minmax", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = "minmax")
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 3L),
     arg = rep(3:5, 2L),
@@ -109,7 +115,7 @@ test_that("PipeOpFDAInterpol works with intersect", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = "intersect")
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   expect_equal(task_interpol$data(), dt)
 
   # tfi works with same min and max
@@ -122,7 +128,7 @@ test_that("PipeOpFDAInterpol works with intersect", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = "intersect")
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 3L),
     arg = rep(c(1, 3, 5), 2L),
@@ -142,7 +148,7 @@ test_that("PipeOpFDAInterpol works with intersect", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = "intersect")
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 3L),
     arg = rep(3:5, 2L),
@@ -164,12 +170,12 @@ test_that("PipeOpFDAInterpol works with union", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = "union")
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   expect_equal(task_interpol$data(), dt)
 
   # works with default
   pop = po("fda.interpol")
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   expect_equal(task_interpol$data(), dt)
 
   # tfi works with same min and max
@@ -182,7 +188,7 @@ test_that("PipeOpFDAInterpol works with union", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = "union")
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 5L),
     arg = rep(1:5, 2L),
@@ -202,8 +208,7 @@ test_that("PipeOpFDAInterpol works with union", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = "union")
-  expect_warning(pop$train(list(task)))
-  task_interpol = suppressWarnings(pop$train(list(task))[[1L]])
+  expect_warning(task_interpol <- train_pipeop(pop, list(task))[[1L]])
   dt = data.table(
     id = c(rep(1L, 3L), rep(2L, 6L)),
     arg = c(3:5, 1:6),
@@ -225,7 +230,7 @@ test_that("PipeOpFDAInterpol works with custom grid", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = 3:5)
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 3L),
     arg = rep(3:5, 2L),
@@ -237,9 +242,9 @@ test_that("PipeOpFDAInterpol works with custom grid", {
 
   # outside of range
   pop = po("fda.interpol", grid = 3:7)
-  expect_error(pop$train(list(task)), "The grid must be within the range of the domain.")
+  expect_error(train_pipeop(pop, list(task)), "The grid must be within the range of the domain.")
   pop = po("fda.interpol", grid = -1:3)
-  expect_error(pop$train(list(task)), "The grid must be within the range of the domain.")
+  expect_error(train_pipeop(pop, list(task)), "The grid must be within the range of the domain.")
 
   # tfi works with same min and max
   dt = data.table(
@@ -251,7 +256,7 @@ test_that("PipeOpFDAInterpol works with custom grid", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = 3:5)
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 3L),
     arg = rep(3:5, 2L),
@@ -271,7 +276,7 @@ test_that("PipeOpFDAInterpol works with custom grid", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = 3:5)
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 3L),
     arg = rep(3:5, 2L),
@@ -293,7 +298,7 @@ test_that("PipeOpFDAInterpol works with grid length + left and right", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = 3L, left = 2, right = 4)
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 3L),
     arg = rep(2:4, 2L),
@@ -313,7 +318,7 @@ test_that("PipeOpFDAInterpol works with grid length + left and right", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = 3L, left = 2, right = 5)
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 3L),
     arg = rep(c(2, 3.5, 5), 2L),
@@ -333,7 +338,7 @@ test_that("PipeOpFDAInterpol works with grid length + left and right", {
   dt = data.table(y = 1:2, f = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.interpol", grid = 3L, left = 3, right = 5)
-  task_interpol = pop$train(list(task))[[1L]]
+  task_interpol = train_pipeop(pop, list(task))[[1L]]
   dt = data.table(
     id = rep(1:2, each = 3L),
     arg = rep(3:5, 2L),
@@ -361,7 +366,7 @@ test_that("PipeOpFDAInterpol method arg works", {
     dt = data.table(y = 1:2, f = f)
     task = as_task_regr(dt, target = "y")
     pop = po("fda.interpol", grid = 3:5, method = method)
-    task_interpol = pop$train(list(task))[[1L]]
+    task_interpol = train_pipeop(pop, list(task))[[1L]]
 
     evaluator = paste0("tf_approx_", method)
     f = do.call(tf::tfd, list(data = dt_out, id = "id", arg = "arg", value = "value", evaluator = evaluator))

--- a/tests/testthat/test_PipeOpFDASmooth.R
+++ b/tests/testthat/test_PipeOpFDASmooth.R
@@ -5,20 +5,13 @@ test_that("PipeOpFDASmooth - basic properties", {
 })
 
 test_that("PipeOpFDASmooth", {
-  po_smooth = po("fda.smooth")
-  # regular
-  task1 = tsk("fuel")
-  task1$col_roles$feature = "NIR"
-  # irregular
-  task2 = tsk("dti")
-  task2$col_roles$feature = "cca"
-
   test_cca = function(method, args) {
+    po_smooth = po("fda.smooth")
     x = task2$data(cols = "cca")$cca
 
     po_smooth$param_set$set_values(method = method, args = args)
-    observed_train = po_smooth$train(list(task2))[[1L]]$data(cols = "cca")[[1L]]
-    observed_predict = po_smooth$predict(list(task2))[[1L]]$data(cols = "cca")[[1L]]
+    observed_train = train_pipeop(po_smooth, list(task2))[[1L]]$data(cols = "cca")[[1L]]
+    observed_predict = predict_pipeop(po_smooth, list(task2))[[1L]]$data(cols = "cca")[[1L]]
 
     expected = suppressMessages(invoke(tf::tf_smooth, x = x, method = method, .args = args))
 
@@ -27,11 +20,12 @@ test_that("PipeOpFDASmooth", {
   }
 
   test_nir = function(method, args) {
+    po_smooth = po("fda.smooth")
     x = task1$data(cols = "NIR")$NIR
 
     po_smooth$param_set$set_values(method = method, args = args)
-    observed_train = po_smooth$train(list(task1))[[1L]]$data(cols = "NIR")[[1L]]
-    observed_predict = po_smooth$predict(list(task1))[[1L]]$data(cols = "NIR")[[1L]]
+    observed_train = train_pipeop(po_smooth, list(task1))[[1L]]$data(cols = "NIR")[[1L]]
+    observed_predict = predict_pipeop(po_smooth, list(task1))[[1L]]$data(cols = "NIR")[[1L]]
 
     expected = suppressMessages(invoke(tf::tf_smooth, x = x, method = method, .args = args))
 
@@ -39,6 +33,13 @@ test_that("PipeOpFDASmooth", {
     expect_equal(observed_predict, expected)
 
   }
+
+  # regular
+  task1 = tsk("fuel")
+  task1$col_roles$feature = "NIR"
+  # irregular
+  task2 = tsk("dti")
+  task2$col_roles$feature = "cca"
 
   test_nir("lowess", list(f = 0.3))
   test_cca("lowess", list(f = 0.2))
@@ -48,8 +49,10 @@ test_that("PipeOpFDASmooth", {
   test_nir("savgol", list())
 
   # verbose parameter is respected
+  po_smooth = po("fda.smooth")
   po_smooth$param_set$set_values(verbose = TRUE)
-  expect_message(po_smooth$train(list(task1)), "using")
+  expect_message(train_pipeop(po_smooth, list(task1)), "using")
+  po_smooth = po("fda.smooth")
   po_smooth$param_set$set_values(verbose = FALSE)
-  expect_message(po_smooth$train(list(task1)), NA)
+  expect_message(train_pipeop(po_smooth, list(task1)), NA)
 })

--- a/tests/testthat/test_PipeOpFPCA.R
+++ b/tests/testthat/test_PipeOpFPCA.R
@@ -19,19 +19,19 @@ test_that("PipeOpPCA works", {
   task = as_task_regr(dt, target = "y")
 
   pop = po("fda.fpca")
-  task_fpc = pop$train(list(task))[[1L]]
+  task_fpc = train_pipeop(pop, list(task))[[1L]]
   expect_task(task_fpc)
   new_data = task_fpc$data()
   expect_identical(dim(new_data), c(2L, 2L))
   expect_named(new_data, c("y", "f_pc_1"))
   expect_numeric(new_data$f_pc_1, len = 2)
-  expect_identical(new_data, pop$predict(list(task))[[1L]]$data())
+  expect_identical(new_data, predict_pipeop(pop, list(task))[[1L]]$data())
 
   # n_components works
   dt = data.table(y = rnorm(15L), f = tf::tf_rgp(15L))
   task = as_task_regr(dt, target = "y")
   pop = po("fda.fpca", n_components = 2L)
-  new_data = pop$train(list(task))[[1L]]$data()
+  new_data = train_pipeop(pop, list(task))[[1L]]$data()
   expect_identical(dim(new_data), c(15L, 3L))
   expect_named(new_data, c("y", "f_pc_1", "f_pc_2"))
 
@@ -45,7 +45,7 @@ test_that("PipeOpPCA works", {
   dt = data.table(y = rnorm(10L), f = f, g = f, h = f)
   task = as_task_regr(dt, target = "y")
   pop = po("fda.fpca")
-  task_fpc = pop$train(list(task))[[1L]]
+  task_fpc = train_pipeop(pop, list(task))[[1L]]
   new_data = task_fpc$data()
   expect_task(task_fpc)
   expect_identical(dim(new_data), c(10L, 10L))
@@ -55,11 +55,11 @@ test_that("PipeOpPCA works", {
     "h_pc_1", "h_pc_2", "h_pc_3"
   )
   expect_named(new_data, nms)
-  expect_identical(new_data, pop$predict(list(task))[[1L]]$data())
+  expect_identical(new_data, predict_pipeop(pop, list(task))[[1L]]$data())
 
   # n_components works
   pop = po("fda.fpca", n_components = 2L)
-  new_data = pop$train(list(task))[[1L]]$data()
+  new_data = train_pipeop(pop, list(task))[[1L]]$data()
   expect_identical(dim(new_data), c(10L, 7L))
   nms = c(
     "y", "f_pc_1", "f_pc_2",
@@ -70,7 +70,7 @@ test_that("PipeOpPCA works", {
 
   # affect_columns works
   pop = po("fda.fpca", affect_columns = selector_name("f"))
-  task_fpc = pop$train(list(task))[[1L]]
+  task_fpc = train_pipeop(pop, list(task))[[1L]]
   expect_set_equal(task_fpc$feature_names, c("f_pc_1", "f_pc_2", "f_pc_3", "g", "h"))
 
   # does not touch irreg
@@ -83,6 +83,7 @@ test_that("PipeOpPCA works", {
   y = 1:2
   dt = data.table(f = f, y = y)
   task = as_task_regr(dt, target = "y")
-  task_fpca = pop$train(list(task))[[1L]]
+  pop = po("fda.fpca")
+  task_fpca = train_pipeop(pop, list(task))[[1L]]
   expect_set_equal(task$feature_names, task_fpca$feature_names)
 })

--- a/tests/testthat/test_PipeOpScaleRange.R
+++ b/tests/testthat/test_PipeOpScaleRange.R
@@ -7,7 +7,7 @@ test_that("PipeOpScaleRange - basic properties", {
 test_that("PipeOpScaleRange works", {
   task = tsk("fuel")
   pop = po("fda.scalerange")
-  task_scale = pop$train(list(task))[[1L]]
+  task_scale = train_pipeop(pop, list(task))[[1L]]
   new_data = task_scale$data()
   expect_task(task_scale)
   expect_identical(dim(new_data), c(129L, 4L))
@@ -15,11 +15,11 @@ test_that("PipeOpScaleRange works", {
   expect_named(new_data, names(new_data))
   expect_numeric(tf::tf_arg(new_data$NIR), lower = 0, upper = 1)
   expect_numeric(tf::tf_arg(new_data$UVVIS), lower = 0, upper = 1)
-  expect_identical(new_data, pop$predict(list(task))[[1L]]$data())
+  expect_identical(new_data, predict_pipeop(pop, list(task))[[1L]]$data())
 
   # different range works
   pop = po("fda.scalerange", lower = -1, upper = 1)
-  task_scale = pop$train(list(task))[[1L]]
+  task_scale = train_pipeop(pop, list(task))[[1L]]
   new_data = task_scale$data()
   expect_equal(tf::tf_domain(new_data$NIR), c(-1, 1))
   expect_equal(range(tf::tf_arg(new_data$NIR)), c(-1, 1))
@@ -28,16 +28,16 @@ test_that("PipeOpScaleRange works", {
 
   # throws error if new data has different domain
   pop = po("fda.scalerange")
-  pop$train(list(task))
+  train_pipeop(pop, list(task))
   expect_error(
-    pop$predict(list(task_scale)),
+    predict_pipeop(pop, list(task_scale)),
     "Domain of new data does not match the domain of the training data."
   )
 
   # irregular data works
   task = tsk("dti")
   pop = po("fda.scalerange", lower = -1, upper = 1)
-  new_data = pop$train(list(task))[[1L]]$data()
+  new_data = train_pipeop(pop, list(task))[[1L]]$data()
   expect_equal(tf::tf_domain(new_data$cca), c(-1, 1))
   expect_equal(tf::tf_domain(new_data$rcst), c(-1, 1))
 })

--- a/tests/testthat/test_tf.R
+++ b/tests/testthat/test_tf.R
@@ -5,7 +5,7 @@ test_that("tf does not support NAs", {
   # https://github.com/tidyfun/tf/issues/33
   # Currently, NA functions are dropped
   d = data.frame(time = 1, value = NA_real_, id = "1", stringsAsFactors = FALSE)
-  x = invisible(tf::tfd(d, arg = "time", value = "value", id = "id"))
+  x = tf::tfd(d, arg = "time", value = "value", id = "id")
   expect_length(x, 0L)
 })
 


### PR DESCRIPTION
closes: https://github.com/mlr-org/mlr3fda/issues/131