### PR TITLE
chore: bump min R version to 3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ BugReports: https://github.com/mlr-org/mlr3fda/issues
 Depends:
     mlr3 (>= 0.14.0),
     mlr3pipelines (>= 0.5.2),
-    R (>= 3.1.0)
+    R (>= 3.3.0)
 Imports:
     checkmate,
     data.table,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ BugReports: https://github.com/mlr-org/mlr3fda/issues
 Depends:
     mlr3 (>= 0.14.0),
     mlr3pipelines (>= 0.5.2),
-    R (>= 3.3.0)
+    R (>= 4.1.0)
 Imports:
     checkmate,
     data.table,


### PR DESCRIPTION
data.table has increased its R version to 3.3 since the latest 1.16 release. Technically we should move to R 4.1 since tf uses 4.1 and this will likely not change.