### PR TITLE
Support Paradox 2 diagnostics in FDA snapshots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # mlr3fda (development version)
 
+* fix: Version validation-error snapshots for compatibility with paradox 2.0.0.
+
 # mlr3fda 0.7.1
 
 * Compatibility with new `tf` version 0.5.0.

--- a/tests/testthat/_snaps/paradox-2/PipeOpFDAWavelets.md
+++ b/tests/testthat/_snaps/paradox-2/PipeOpFDAWavelets.md
@@ -4,7 +4,7 @@
       po("fda.wavelets", filter = "la4")
     Condition
       Error in `.__ParamSet__values()`:
-      ! filter: Must be element of set {'d2','d4','d6','d8','d10','d12','d14','d16','d18','d20','la8','la10','la12','la14','la16','la18','la20','bl14','bl18','bl20','c6','c12','c18','c24','c30','haar'}, but is 'la4'
+      ! Assertion on 'xs' failed: filter: Must be element of set {'d2','d4','d6','d8','d10','d12','d14','d16','d18','d20','la8','la10','la12','la14','la16','la18','la20','bl14','bl18','bl20','c6','c12','c18','c24','c30','haar'}, but is 'la4'.
 
 ---
 
@@ -12,7 +12,7 @@
       po("fda.wavelets", filter = "invalid_filter")
     Condition
       Error in `.__ParamSet__values()`:
-      ! filter: Must be element of set {'d2','d4','d6','d8','d10','d12','d14','d16','d18','d20','la8','la10','la12','la14','la16','la18','la20','bl14','bl18','bl20','c6','c12','c18','c24','c30','haar'}, but is 'invalid_filter'
+      ! Assertion on 'xs' failed: filter: Must be element of set {'d2','d4','d6','d8','d10','d12','d14','d16','d18','d20','la8','la10','la12','la14','la16','la18','la20','bl14','bl18','bl20','c6','c12','c18','c24','c30','haar'}, but is 'invalid_filter'.
 
 ---
 
@@ -20,7 +20,7 @@
       po("fda.wavelets", filter = c(1, 2, 3))
     Condition
       Error in `.__ParamSet__values()`:
-      ! filter: Must be either a string, an even numeric vector or wavelet filter object
+      ! Assertion on 'xs' failed: filter: Must be either a string, an even numeric vector or wavelet filter object.
 
 ---
 
@@ -28,4 +28,4 @@
       po("fda.wavelets", filter = list("la8"))
     Condition
       Error in `.__ParamSet__values()`:
-      ! filter: Must be either a string, an even numeric vector or wavelet filter object
+      ! Assertion on 'xs' failed: filter: Must be either a string, an even numeric vector or wavelet filter object.

--- a/tests/testthat/_snaps/paradox-2/PipeOpFDAWavelets.md
+++ b/tests/testthat/_snaps/paradox-2/PipeOpFDAWavelets.md
@@ -1,0 +1,31 @@
+# PipeOpFDAWavelets input validation
+
+    Code
+      po("fda.wavelets", filter = "la4")
+    Condition
+      Error in `.__ParamSet__values()`:
+      ! filter: Must be element of set {'d2','d4','d6','d8','d10','d12','d14','d16','d18','d20','la8','la10','la12','la14','la16','la18','la20','bl14','bl18','bl20','c6','c12','c18','c24','c30','haar'}, but is 'la4'
+
+---
+
+    Code
+      po("fda.wavelets", filter = "invalid_filter")
+    Condition
+      Error in `.__ParamSet__values()`:
+      ! filter: Must be element of set {'d2','d4','d6','d8','d10','d12','d14','d16','d18','d20','la8','la10','la12','la14','la16','la18','la20','bl14','bl18','bl20','c6','c12','c18','c24','c30','haar'}, but is 'invalid_filter'
+
+---
+
+    Code
+      po("fda.wavelets", filter = c(1, 2, 3))
+    Condition
+      Error in `.__ParamSet__values()`:
+      ! filter: Must be either a string, an even numeric vector or wavelet filter object
+
+---
+
+    Code
+      po("fda.wavelets", filter = list("la8"))
+    Condition
+      Error in `.__ParamSet__values()`:
+      ! filter: Must be either a string, an even numeric vector or wavelet filter object

--- a/tests/testthat/_snaps/paradox-2/PipeOpFDAWavelets.md
+++ b/tests/testthat/_snaps/paradox-2/PipeOpFDAWavelets.md
@@ -3,7 +3,7 @@
     Code
       po("fda.wavelets", filter = "la4")
     Condition
-      Error in `.__ParamSet__values()`:
+      Error in `.__paradox2_ParamSet__values()`:
       ! Assertion on 'xs' failed: filter: Must be element of set {'d2','d4','d6','d8','d10','d12','d14','d16','d18','d20','la8','la10','la12','la14','la16','la18','la20','bl14','bl18','bl20','c6','c12','c18','c24','c30','haar'}, but is 'la4'.
 
 ---
@@ -11,7 +11,7 @@
     Code
       po("fda.wavelets", filter = "invalid_filter")
     Condition
-      Error in `.__ParamSet__values()`:
+      Error in `.__paradox2_ParamSet__values()`:
       ! Assertion on 'xs' failed: filter: Must be element of set {'d2','d4','d6','d8','d10','d12','d14','d16','d18','d20','la8','la10','la12','la14','la16','la18','la20','bl14','bl18','bl20','c6','c12','c18','c24','c30','haar'}, but is 'invalid_filter'.
 
 ---
@@ -19,7 +19,7 @@
     Code
       po("fda.wavelets", filter = c(1, 2, 3))
     Condition
-      Error in `.__ParamSet__values()`:
+      Error in `.__paradox2_ParamSet__values()`:
       ! Assertion on 'xs' failed: filter: Must be either a string, an even numeric vector or wavelet filter object.
 
 ---
@@ -27,5 +27,5 @@
     Code
       po("fda.wavelets", filter = list("la8"))
     Condition
-      Error in `.__ParamSet__values()`:
+      Error in `.__paradox2_ParamSet__values()`:
       ! Assertion on 'xs' failed: filter: Must be either a string, an even numeric vector or wavelet filter object.

--- a/tests/testthat/test_PipeOpFDAWavelets.R
+++ b/tests/testthat/test_PipeOpFDAWavelets.R
@@ -6,13 +6,14 @@ test_that("PipeOpFDAWavelets - basic properties", {
 
 test_that("PipeOpFDAWavelets input validation", {
   skip_if_not_installed("wavelets")
+  snapshot_variant = if (packageVersion("paradox") >= "2.0.0") "paradox-2" else NULL
   expect_no_error(po("fda.wavelets", filter = wavelets::wt.filter()))
   expect_no_error(po("fda.wavelets", filter = "la8"))
   expect_no_error(po("fda.wavelets", filter = 1:10))
-  expect_snapshot(po("fda.wavelets", filter = "la4"), error = TRUE)
-  expect_snapshot(po("fda.wavelets", filter = "invalid_filter"), error = TRUE)
-  expect_snapshot(po("fda.wavelets", filter = c(1, 2, 3)), error = TRUE)
-  expect_snapshot(po("fda.wavelets", filter = list("la8")), error = TRUE)
+  expect_snapshot(po("fda.wavelets", filter = "la4"), error = TRUE, variant = snapshot_variant)
+  expect_snapshot(po("fda.wavelets", filter = "invalid_filter"), error = TRUE, variant = snapshot_variant)
+  expect_snapshot(po("fda.wavelets", filter = c(1, 2, 3)), error = TRUE, variant = snapshot_variant)
+  expect_snapshot(po("fda.wavelets", filter = list("la8")), error = TRUE, variant = snapshot_variant)
 })
 
 test_that("PipeOpFDAWavelets works", {


### PR DESCRIPTION
> Keep the existing Paradox 1 wavelet-pipeline error snapshots byte-for-byte
> unchanged and select a Paradox-2 snapshot variant only when that major is
> installed. The informative diagnostic content and punctuation are now the
> same on both axes; the variant remains necessary only because Paradox 2's
> native assignment reports the current versioned
> `.__paradox2_ParamSet__values()` call header instead of Paradox 1's
> `self$assert()` header. Pipeline construction and FDA behavior are unchanged.

- **test: support paradox 2 error snapshots**
- **Keep Paradox 2 snapshots focused on call context**
- **Update Paradox 2 wavelet snapshot call headers**
